### PR TITLE
feat: add read global config on cwd

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -10,9 +10,6 @@ inputs:
   build:
     description: Build packages
     default: "true"
-  sub-dir:
-    description: Is run in src sub directory
-    default: "false"
 runs:
   using: composite
   steps:

--- a/src/lib/global-config/global-config-handler.ts
+++ b/src/lib/global-config/global-config-handler.ts
@@ -1,4 +1,4 @@
-import { read, readUser, write, writeUser } from "rc9";
+import { read, readUserConfig, write, writeUserConfig } from "rc9";
 
 import { GLOBAL_CONFIG_FILE_NAME } from "@lib/constants";
 import { type DeepPartial } from "@lib/types";
@@ -12,9 +12,11 @@ type CReader = (options: { name: string; dir?: string }) => GlobalConfig;
 
 export class GlobalConfigHandler {
   static read(dir?: string): GlobalConfig {
-    const localConfig = this._readConfig(read, false, dir);
-    if (localConfig) return localConfig;
-    return this._readConfig(readUser, true);
+    const dirConfig = this._readConfig(read, false, dir);
+    if (dirConfig) return dirConfig;
+    const cwdConfig = this._readConfig(read, false, process.cwd());
+    if (cwdConfig) return cwdConfig;
+    return this._readConfig(readUserConfig, true);
   }
 
   static write(config: DeepPartial<GlobalConfig>, local: boolean = false, dir?: string): void {
@@ -23,7 +25,7 @@ export class GlobalConfigHandler {
       dir,
     };
     if (local) write(config, options);
-    else writeUser(config, options);
+    else writeUserConfig(config, options);
   }
 
   private static _readConfig(func: CReader, force: true): GlobalConfig;


### PR DESCRIPTION
## What does this PR do?

Add global config read on cwd. It allow the user to use `nf publish -d` with a local config where running the command to handle monorepo

## How do you test this PR?
