### PR TITLE
feat: add ssl config to json configuration

### DIFF
--- a/src/action/actions/start.action.ts
+++ b/src/action/actions/start.action.ts
@@ -42,7 +42,7 @@ export class StartAction extends AbstractAction {
     const serverDir = getStringInputWithDefault(options, "serverDir", config.server.outDir);
     const watch = getWatchInput(options);
     const port = getStringInputWithDefault(options, "port", config.client.port);
-    const ssl = this.resolveSSL(options);
+    const ssl = this.resolveSSL(options, config);
 
     const tasks = this.buildStartTasks(config, directory, {
       clientDir,
@@ -56,14 +56,29 @@ export class StartAction extends AbstractAction {
     return { keepAlive: true };
   }
 
-  private resolveSSL(options: Input): SSLOptions | undefined {
-    const cert = getStringInput(options, "cert");
-    const key = getStringInput(options, "key");
+  private resolveSSL(options: Input, config: Config): SSLOptions | undefined {
+    const cliCert = getStringInput(options, "cert");
+    const cliKey = getStringInput(options, "key");
+    const isSslRequested = Boolean(cliCert || cliKey || config.ssl?.enable);
 
-    if (!cert && !key) return undefined;
+    if (!isSslRequested) return undefined;
 
-    if (!cert) throw new CLIError("No cert entered for SSL. Please enter a cert with --cert.");
-    if (!key) throw new CLIError("No key entered for SSL. Please enter a key with --key.");
+    const cert = cliCert || config.ssl?.cert;
+    const key = cliKey || config.ssl?.key;
+
+    if (!cert) {
+      throw new CLIError(
+        "No certificate found for SSL.",
+        "Please provide a certificate path with --cert or configure 'ssl.cert' in your nanoforge.config.json.",
+      );
+    }
+
+    if (!key) {
+      throw new CLIError(
+        "No key found for SSL.",
+        "Please provide a key path with --key or configure 'ssl.key' in your nanoforge.config.json.",
+      );
+    }
 
     return {
       cert,

--- a/src/action/actions/start.action.ts
+++ b/src/action/actions/start.action.ts
@@ -63,8 +63,8 @@ export class StartAction extends AbstractAction {
 
     if (!isSslRequested) return undefined;
 
-    const cert = cliCert || config.ssl?.cert;
-    const key = cliKey || config.ssl?.key;
+    const cert = cliCert ? cliCert : config.ssl?.cert;
+    const key = cliKey ? cliKey : config.ssl?.key;
 
     if (!cert) {
       throw new CLIError(

--- a/src/lib/config/config-defaults.ts
+++ b/src/lib/config/config-defaults.ts
@@ -4,6 +4,11 @@ export const CONFIG_DEFAULTS: Config = {
   name: "nanoforge-app",
   language: "ts",
   initFunctions: true,
+  ssl: {
+    enable: false,
+    cert: "",
+    key: "",
+  },
   client: {
     enable: true,
     port: "3000",

--- a/src/lib/config/config.type.ts
+++ b/src/lib/config/config.type.ts
@@ -93,6 +93,20 @@ export class ServerConfig {
   dirs!: DirsConfig;
 }
 
+export class SslConfig {
+  @Expose()
+  @IsBoolean()
+  enable!: boolean;
+
+  @Expose()
+  @IsString()
+  cert!: string;
+
+  @Expose()
+  @IsString()
+  key!: string;
+}
+
 export class Config {
   @Expose()
   @IsString()
@@ -116,4 +130,9 @@ export class Config {
   @Type(() => ServerConfig)
   @ValidateNested()
   server!: ServerConfig;
+
+  @Expose()
+  @Type(() => SslConfig)
+  @ValidateNested()
+  ssl!: SslConfig;
 }


### PR DESCRIPTION
## What does this PR do?

This PR resolves issue #156 by allowing users to define their SSL configuration directly within the `nanoforge.config.json` file, removing the strict need to pass `--cert` and `--key` as CLI arguments every time.

**Key changes:**
* Added an `SslConfig` block (`enable`, `cert`, `key`) to `config.type.ts` and `config-defaults.ts`.
* Updated the `resolveSSL` method in `start.action.ts` to read from the JSON config if the CLI arguments are missing.
* Kept CLI arguments as the priority (overriding JSON config if both are provided).
* Added proper `CLIError` handling with suggestions if SSL is requested but certificates/keys are missing from both the CLI args and the JSON config.

Closes #156

## How do you test this PR?

1. Build the CLI (`pnpm run build`).
2. Go to a NanoForge project directory.
3. Add the following block to your `nanoforge.config.json`:
   ```json
   "ssl": {
     "enable": true,
     "cert": "path/to/cert",
     "key": "path/to/key"
   }