### PR TITLE
feat(editor): display clickable link when starting editor

### DIFF
--- a/src/action/actions/editor.action.ts
+++ b/src/action/actions/editor.action.ts
@@ -18,10 +18,14 @@ export class EditorAction extends AbstractAction {
   public async handle(args: Input, options: Input): Promise<HandleResult> {
     const directory = getDirectoryInput(options);
     const path = getPathInput(args);
-    const open = getEditorOpenInput(options, !!path);
+    const shouldOpen = getEditorOpenInput(options, !!path);
+    const query = path ? `?projectPath=${encodeURIComponent(path)}` : "";
+    const url = `http://localhost:3000/load-project${query}`;
+
+    console.log(`\n🔗 Editor running! Open it in your browser: \x1b[36m${url}\x1b[0m\n`);
 
     void this.startEditor(directory);
-    if (open) await this.openEditor(path);
+    if (shouldOpen) await this.openBrowser(url);
 
     return { keepAlive: true };
   }
@@ -39,9 +43,7 @@ export class EditorAction extends AbstractAction {
     });
   }
 
-  private async openEditor(path: string | undefined): Promise<void> {
-    const query = path ? `?projectPath=${encodeURIComponent(path)}` : "";
-    const url = `http://localhost:3000/load-project${query}`;
+  private async openBrowser(url: string): Promise<void> {
     await open(url);
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR resolves issue #175 by explicitly displaying a clickable link in the terminal when the `nf editor` command is run. 

**Key changes:**
* Extracted the URL generation logic from the `openEditor` method to the main `handle` method.
* Added a console output to display the generated link (with cyan formatting for visibility).
* This ensures that users always see the editor link in their terminal, which is especially useful if they run the command with the `--no-open` flag or if the automatic browser launch fails.

Closes #175

## How do you test this PR?

1. Build the CLI (`pnpm run build`).
2. Run `nf editor` or `nf editor --no-open`.
3. Verify that the terminal logs `🔗 Editor running! Open it in your browser: http://localhost:3000/load-project...`
4. Click the link to ensure it properly targets the editor.